### PR TITLE
Support server-provided certificate chain

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -9,6 +9,8 @@ pub struct BlazeServerData {
     pub private_key: RsaPrivateKey,
     /// The server certificate
     pub certificate: Arc<Certificate>,
+    /// Additional certificate authority certificates proceeding sequentially upward 
+    pub certificate_chain: Vec<Arc<Certificate>>,
 }
 
 impl Default for BlazeServerData {
@@ -26,6 +28,7 @@ impl Default for BlazeServerData {
         Self {
             private_key,
             certificate,
+            certificate_chain: Vec::new(),
         }
     }
 }

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -214,11 +214,19 @@ impl HandshakingWrapper {
         Ok(random)
     }
 
-    /// Emits a Certificate message containing the server certificate
+    /// Emits a Certificate message containing the server certificates
     async fn emit_certificate(&mut self) -> BlazeResult<()> {
         let server_data = self.ty.server_data();
+
+        let mut certificates: Vec<Certificate> = Vec::new();
+        certificates.push((*server_data.certificate).clone());
+
+        for cert in &server_data.certificate_chain {
+            certificates.push((**cert).clone());
+        }
+
         let message: Message =
-            HandshakePayload::Certificate(ServerCertificate::Send(server_data.certificate.clone()))
+            HandshakePayload::Certificate(ServerCertificate::Send(certificates))
                 .into();
         self.write_and_flush(message).await
     }

--- a/src/msg/handshake.rs
+++ b/src/msg/handshake.rs
@@ -1,5 +1,4 @@
 use super::{codec::*, types::*, Message};
-use std::sync::Arc;
 
 /// Different types of payloads that can be stored within handshake
 /// messages. Names match up with the name for the type of message
@@ -163,14 +162,16 @@ impl Codec for ServerHello {
 /// Message that server sends to clients containing a list of
 /// certificates that are available to the server
 pub enum ServerCertificate {
-    Send(Arc<Certificate>),
+    Send(Vec<Certificate>),
     Recieve(Vec<Certificate>),
 }
 
 impl Codec for ServerCertificate {
     fn encode(&self, output: &mut Vec<u8>) {
         match self {
-            Self::Send(certificate) => encode_u24_item(output, &**certificate),
+            Self::Send(certificates) => {
+                encode_vec_u24(output, certificates);
+            },
             Self::Recieve(certificates) => {
                 encode_vec_u24(output, certificates);
             }


### PR DESCRIPTION
SSLv3 supports sending [additional CA certificates](https://www.rfc-editor.org/rfc/rfc6101.html#section-5.6.2:~:text=followed%0A%20%20%20%20%20%20by%20any%20certificate%20authority%20certificates%20proceeding%20sequentially%0A%20%20%20%20%20%20upward.) to represent the certificate chain in the server certificate message.